### PR TITLE
linearRGB invert

### DIFF
--- a/toggle.js
+++ b/toggle.js
@@ -8,13 +8,22 @@ style.innerText = `html, .loading-screen.ng-scope, .history-entries, .history-la
 }
 
 .cm-editor, .ace_editor, .pdf-viewer, .pdfjs-controls, .project-list-main, .project-list-main .fa-circle, .site-footer, #review-panel, .modal-body, .ui-layout-mask, #left-menu, .history-entry-day, .loading-panel, #editor-rich-text {
-    filter: invert(100%);
-    -webkit-filter: invert(100%);
+    filter: url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg">\
+      <filter id="invert" color-interpolation-filters="linearRGB">\
+        <feColorMatrix in="SourceGraphic" type="matrix"\
+          values="-0.98701696766 0 0 0 1\
+            0 -0.98701696766 0 0 1\
+            0 0 -0.98701696766 0 1\
+            0 0 0 1 0" />\
+      </filter>\
+    </svg>#invert');
 }
 
 .project-list-main {
     background-color: #f4f5f8;
 }`
+
+// -webkit-filter: invert(100%);
 
 chrome.storage.sync.get(['darkMode'], function(result) {
     if (result.darkMode) document.body.appendChild(style)


### PR DESCRIPTION
The CSS filer invert operates on sRGB values. sRGB values are related to RGB intensities by a non-linear function. Because of that, CSS invert results in incorrect subpixel rendering and consequently in thinning of lines (that depends on sub-pixel positioning) as well as in color artifacts at non-horizontal edges. This pull request fixes that by instead using an SVG filter in the `linearRGB` color space. The number `-0.98701696766` instead of `-1` makes the background dark gray, same color as in VSCode:

    filter: url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg">\
      <filter id="invert" color-interpolation-filters="linearRGB">\
        <feColorMatrix in="SourceGraphic" type="matrix"\
          values="-0.98701696766 0 0 0 1\
            0 -0.98701696766 0 0 1\
            0 0 -0.98701696766 0 1\
            0 0 0 1 0" />\
      </filter>\
    </svg>#invert');

![image](https://github.com/tusharmurali/overleaf-dark-mode/assets/39674044/37fec9b1-6a00-44d6-ae32-017f7ceafcc4)
_Top: original, mid: night mode, bottom: night mode with this pull request_

I also tried preserving hue. While the colors looks nice, preserving hue breaks subpixel rendering that takes advantage of the order of display RGB elements and thus makes things mushier. Anyways, here is the matrix for that and how that looked:

    "0 -0.49350848383 -0.49350848383 0 1\
    -0.49350848383 0 -0.49350848383 0 1\
    -0.49350848383 -0.49350848383 0 0 1\
    0 0 0 1 0"

![image](https://github.com/tusharmurali/overleaf-dark-mode/assets/39674044/7a86dbf9-28b0-4b29-8ad9-fa13ba63764c)
_Preserving hue_